### PR TITLE
Adding name metadata attr

### DIFF
--- a/chef/cookbooks/apt/metadata.rb
+++ b/chef/cookbooks/apt/metadata.rb
@@ -1,3 +1,4 @@
+name              "apt"
 maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"

--- a/chef/cookbooks/java/metadata.rb
+++ b/chef/cookbooks/java/metadata.rb
@@ -1,3 +1,4 @@
+name              "java"
 maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"

--- a/chef/cookbooks/jpackage/metadata.rb
+++ b/chef/cookbooks/jpackage/metadata.rb
@@ -1,3 +1,4 @@
+name             "jpackage"
 maintainer       "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"

--- a/chef/cookbooks/tomcat/metadata.rb
+++ b/chef/cookbooks/tomcat/metadata.rb
@@ -1,3 +1,4 @@
+name             "tomcat"
 maintainer       "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"

--- a/chef/cookbooks/webapp/metadata.rb
+++ b/chef/cookbooks/webapp/metadata.rb
@@ -1,3 +1,4 @@
+name             "webapp"
 maintainer       "Eberhard Wolff"
 maintainer_email "eberhard.wolff@gmail.com"
 license          "Apache 2.0 License"


### PR DESCRIPTION
W/ Vagrant( 1.7.1) and chef-solo (12.0.3) it was complaining about lacking name attr. in the `metadata.rb` files
